### PR TITLE
Create conda packaging recipe and associated CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,17 +1,22 @@
 name: CI
 
 on:
-  # Run CI on all pushed commits.
-  push: {}
+  push: 
+    # Run CI on all pushed branches.
+    branches: "*"
+    # Run CI on all versioned tags.
+    tags: "[0-9]+.[0-9]+.[0-9]+"
 
   # Run CI nightly at 03:00 PST (11:00 UTC).
   schedule:
     - cron: "0 11 * * *"
 
+  # Allow maintainers to manually trigger the build.
+  workflow_dispatch: {}
+
 jobs:
-  # TODO: set up documentation tests/deployment
   test:
-    name: Test MDSAPT on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    name: Test on py${{ matrix.python-version }}/${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -53,6 +58,7 @@ jobs:
         python -m pip install . --no-deps
         conda list
 
+    # TODO: possibly integrate this step with meta.yml?
     - name: Run tests
       # conda setup requires this special shell
       shell: bash -l {0}
@@ -67,4 +73,92 @@ jobs:
         flags: unittests
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
 
-  # TODO: set up deployment job
+  package:
+    name: Packaging py${{ matrix.python-version }}/${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: test
+    if: startsWith(github.ref, 'refs/tags')  # only do this on tags
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+        python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: macOS-latest
+            output-folder: osx-64
+          - os: ubuntu-latest
+            output-folder: linux-64
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Cache our conda packages.
+    # More info: https://github.com/conda-incubator/setup-miniconda#caching-packages
+    - name: Cache conda environment
+      uses: actions/cache@v2
+      env:
+        # Increase this value to reset cache if environment.yml has not changed
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-py${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('devtools/deploy/environment.yml') }}
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - name: Set up Anaconda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/deploy/environment.yml
+        channels: conda-forge,omnia,psi4,defaults
+        activate-environment: mdsapt-build
+        auto-update-conda: false
+        auto-activate-base: false
+        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+
+    - name: Build MDSAPT conda package
+      # conda requires this special shell
+      shell: bash -l {0}
+      run: conda build -c psi4 -c conda-forge -c omnia --output-folder . .
+
+    - name: Upload MDSAPT conda package
+      # conda requires this special shell
+      shell: bash -l {0}
+      if: startsWith(github.ref, 'refs/tags')  # only do this on tags
+      env:
+        ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+      run: anaconda upload --label main ${{ matrix.output-folder }}/*.tar.bz2
+
+  verify:
+    name: Test installing py${{ matrix.python-version }}/${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags')  # only do this on tags
+    needs: package
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - name: Create Anaconda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        activate-environment: mdsapt-test
+        auto-update-conda: false
+        auto-activate-base: false
+
+    - name: Install mdsapt from mdsapt-testing
+      shell: bash -l {0}
+      # NOTE: psi4 must be first channel
+      run: >
+        conda install -c psi4 -c defaults -c conda-forge -c omnia -c mdsapt-testing mdsapt 
+
+    - name: Test importing mdsapt
+      shell: bash -l {0}
+      run: >
+        python3 -c "import mdsapt"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Used while building the conda package.
+python setup.py install

--- a/devtools/deploy/environment.yml
+++ b/devtools/deploy/environment.yml
@@ -1,0 +1,9 @@
+# The environment used in CI/package building.
+
+name: mdsapt-build
+channels:
+  - defaults
+dependencies:
+  - anaconda-client
+  - conda-build
+  - conda-verify

--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - pandas
   - pdbfixer=1.6
   - psi4=1.4+9485035
-  - rdkit>=2020.09.3
+  - pytest-cov
   - pyyaml
+  - rdkit>=2020.09.3

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,54 @@
+# This file is used in conda-build.
+
+package:
+  name: mdsapt
+  version: "{{ GIT_DESCRIBE_TAG }}"
+
+source:
+  git_url: ./
+
+about:
+  home: https://github.com/ALescoulie/MDSAPT
+  license: GPL-3.0
+  license_file: LICENSE
+  license_family: GPL3
+  summary: SAPT Calculations for MDAnalysis
+  doc_url: https://mdsapt.readthedocs.io/
+  dev_url: https://github.com/ALescoulie/MDSAPT
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - psi4
+    - mdanalysis
+    - nglview
+    - numpy
+    - openmm
+    - pandas
+    - pdbfixer
+    - python
+    - pyyaml
+    - rdkit
+
+test:
+  imports:
+    - mdsapt
+    - mdsapt.tests
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    # This is currently disabled because it does not work.
+    # However, tests pass when not building.
+    # - pytest -v .
+
+extra:
+  maintainers:
+   - ALescoulie
+   - astralbijection
+  recipe-maintainers:
+   - ALescoulie
+   - astralbijection

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 mdsapt
 An MDA-kit for calcuating quantum interactions in psi4.


### PR DESCRIPTION
## Description
This PR adds a conda recipe and associated CI workflow so we can distribute MDSAPT over Anaconda.

## Todos
  - [x] Add an `ANACONDA_API_TOKEN` with access to the `mdsapt-testing` channel to the ALescoulie/MDSAPT repo secrets
  - [x] ~~Possibly add a thing in documentation saying you need to conda install with psi4 channel first~~ add it in later as a different PR

## Status
- [x] Ready to go